### PR TITLE
Add capability of propagating user data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # .nfs files are created when an open file is removed but is still being accessed
 .nfs*
+dist/
 
 ### macOS ###
 # General

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   - [Summary](#summary)
   - [How this works](#how-this-works)
   - [Basic usage](#basic-usage)
+  - [Adding additional data](#adding-additional-data)
 
 ## How this works
 
@@ -52,3 +53,15 @@ server.start(appFactory, options)
 ```
 
 The error middleware receives a string declaring the current environment for your application. If this environment is different from `production`, then all the error stack will also be displayed.
+
+## Adding additional data
+
+If you'd like to include more data in the error, pass on a `boom` error with `{ additionalData: yourData }` as second parameter.
+
+Example:
+
+```ts
+if (err instanceof ExternalAPIError) return next(boom.serverUnavailable(err.message, { additionalProperties: err.data }))
+```
+
+This will render the added data to the response

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -5,7 +5,7 @@ export function factory (): ErrorRequestHandler {
   return (err: Error, _req: Request, _res: Response, next: NextFunction) => {
     if (!(err instanceof Boom)) {
       const { message, stack } = err
-      return next(Boom.internal(message, { stack: stack, ...err }))
+      return next(Boom.internal(message, { stack: stack }))
     }
 
     next(err)

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -4,7 +4,8 @@ import { Request, Response, NextFunction, ErrorRequestHandler } from 'express'
 export function factory (): ErrorRequestHandler {
   return (err: Error, _req: Request, _res: Response, next: NextFunction) => {
     if (!(err instanceof Boom)) {
-      return next(Boom.internal(err.message, { stack: err.stack }))
+      const { message, stack } = err
+      return next(Boom.internal(message, { stack: stack, ...err }))
     }
 
     next(err)

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -29,9 +29,9 @@ export function factory (environment: string): ErrorRequestHandler {
 
     const code = data && data.code ? data.code : slug(err.output.payload.error, { replacement: '_', lower: true })
 
-    const output = shouldDisplayErrorStack(environment) && data
-      ? { status, error: { code, message, stack: data.stack, data: data.additionalProperties } }
-      : { status, error: { code, message, data: data!.additionalProperties } }
+    const output: { status: number, error: { code: string, message: string, stack?: unknown, data?: unknown } } = { status, error: { code, message } }
+    if (shouldDisplayErrorStack(environment) && data && data.stack) output.error.stack = data.stack
+    if (data && data.additionalProperties) output.error.data = data.additionalProperties
 
     res.status(status)
       .json(output)

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -12,9 +12,10 @@ const shouldDisplayErrorStack = (environment: string): boolean => {
 
 interface IErrorData {
   code?: string
-  stack?: unknown
-  additionalData?: unknown
+  stack?: unknown,
+  additionalProperties?: unknown
 }
+
 type ErrorData = IErrorData | null
 
 /**
@@ -26,13 +27,11 @@ export function factory (environment: string): ErrorRequestHandler {
   return (err: Boom<ErrorData>, _req: Request, res: Response, _next: NextFunction) => {
     const { message, output: { statusCode: status }, data } = err
 
-    const code = data && data.code
-      ? data.code
-      : slug(err.output.payload.error, { replacement: '_', lower: true })
+    const code = data && data.code ? data.code : slug(err.output.payload.error, { replacement: '_', lower: true })
 
-    const output = shouldDisplayErrorStack(environment) && data && data.stack
-      ? { status, error: { code, message, stack: data.stack }, additionalData: err.data }
-      : { status, error: { code, message }, additionalData: err.data }
+    const output = shouldDisplayErrorStack(environment) && data
+      ? { status, error: { code, message, stack: data.stack, data: data.additionalProperties } }
+      : { status, error: { code, message, data: data!.additionalProperties } }
 
     res.status(status)
       .json(output)

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -11,8 +11,9 @@ const shouldDisplayErrorStack = (environment: string): boolean => {
 }
 
 interface IErrorData {
-  code?: string,
+  code?: string
   stack?: unknown
+  additionalData?: unknown
 }
 type ErrorData = IErrorData | null
 
@@ -30,8 +31,8 @@ export function factory (environment: string): ErrorRequestHandler {
       : slug(err.output.payload.error, { replacement: '_', lower: true })
 
     const output = shouldDisplayErrorStack(environment) && data && data.stack
-      ? { status, error: { code, message, stack: data.stack } }
-      : { status, error: { code, message } }
+      ? { status, error: { code, message, stack: data.stack }, additionalData: err.data }
+      : { status, error: { code, message }, additionalData: err.data }
 
     res.status(status)
       .json(output)

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -16,6 +16,8 @@ interface IErrorData {
   additionalProperties?: unknown
 }
 
+type ErrorOutput = { status: number, error: { code: string, message: string, stack?: unknown, data?: unknown } }
+
 type ErrorData = IErrorData | null
 
 /**
@@ -29,7 +31,7 @@ export function factory (environment: string): ErrorRequestHandler {
 
     const code = data && data.code ? data.code : slug(err.output.payload.error, { replacement: '_', lower: true })
 
-    const output: { status: number, error: { code: string, message: string, stack?: unknown, data?: unknown } } = { status, error: { code, message } }
+    const output: ErrorOutput = { status, error: { code, message } }
     if (shouldDisplayErrorStack(environment) && data && data.stack) output.error.stack = data.stack
     if (data && data.additionalProperties) output.error.data = data.additionalProperties
 


### PR DESCRIPTION
All data passed to `boom(message, data)` will be propagated to the end error renderer