### PR TITLE
Feature/remove export factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Import and use it:
 import route from './route'
 import expresso, { IExpressoConfigOptions } from '@expresso/app'
 import server from '@expresso/server'
-import errors from '@expresso/errors'
+import { errors } from '@expresso/errors'
 
 interface IAppConfig extends IAuthConfig, IExpressoConfigOptions {}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@expresso/errors",
-  "version": "1.3.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expresso/errors",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "description": "@expresso express error handling suite",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expresso/errors",
-  "version": "2.3.0",
+  "version": "1.3.1",
   "description": "@expresso express error handling suite",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expresso/errors",
-  "version": "1.3.0",
+  "version": "2.3.0",
   "description": "@expresso express error handling suite",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,4 +19,4 @@ export const stderr = _stderr
 export const renderer = _renderer
 export const normalizer = _normalizer
 
-export { factory as errors}
+export { factory as errors }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,4 +19,4 @@ export const stderr = _stderr
 export const renderer = _renderer
 export const normalizer = _normalizer
 
-export default factory
+export { factory as errors}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,4 +19,5 @@ export const stderr = _stderr
 export const renderer = _renderer
 export const normalizer = _normalizer
 
+export default factory
 export { factory as errors }


### PR DESCRIPTION
Manter o padrão do expresso:
```.ts
import { errors } from '@expresso/errors'
```
O que acham? De qualquer maneira tem que atualizar a doc, pq se seguir ela da ruim, o ruim é que é breaking change..